### PR TITLE
Add Database Transactions in Middleware

### DIFF
--- a/api/controllers/jwt_auth_controller.go
+++ b/api/controllers/jwt_auth_controller.go
@@ -1,8 +1,8 @@
 package controllers
 
 import (
-	"github.com/dipeshdulal/clean-gin/lib"
 	"github.com/dipeshdulal/clean-gin/api/services"
+	"github.com/dipeshdulal/clean-gin/lib"
 	"github.com/gin-gonic/gin"
 )
 
@@ -31,7 +31,7 @@ func (jwt JWTAuthController) SignIn(c *gin.Context) {
 	jwt.logger.Zap.Info("SignIn route called")
 	// Currently not checking for username and password
 	// Can add the logic later if necessary.
-	user, _ := jwt.userService.GetOneUser(uint(3))
+	user, _ := jwt.userService.GetOneUser(uint(1))
 	token := jwt.service.CreateToken(user)
 	c.JSON(200, gin.H{
 		"message": "logged in successfully",

--- a/api/controllers/user_controller.go
+++ b/api/controllers/user_controller.go
@@ -95,6 +95,37 @@ func (u UserController) SaveUser(c *gin.Context) {
 	c.JSON(200, gin.H{"data": "user created"})
 }
 
+// SaveUserWOTrx saves the user without transaction for comparision
+func (u UserController) SaveUserWOTrx(c *gin.Context) {
+	user := models.User{}
+
+	if err := c.ShouldBindJSON(&user); err != nil {
+		u.logger.Zap.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	if err := u.service.CreateUser(user); err != nil {
+		u.logger.Zap.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	if err := u.service.CreateUser(user); err != nil {
+		u.logger.Zap.Error(err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(200, gin.H{"data": "user created"})
+}
+
 // UpdateUser updates user
 func (u UserController) UpdateUser(c *gin.Context) {
 	user := models.User{}

--- a/api/middlewares/db_trx.go
+++ b/api/middlewares/db_trx.go
@@ -1,0 +1,63 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/dipeshdulal/clean-gin/constants"
+	"github.com/dipeshdulal/clean-gin/lib"
+	"github.com/gin-gonic/gin"
+)
+
+// DatabaseTrx middleware for transactions support for database
+type DatabaseTrx struct {
+	handler lib.RequestHandler
+	logger  lib.Logger
+	db      lib.Database
+}
+
+// NewDatabaseTrx creates new database transactions middleware
+func NewDatabaseTrx(
+	handler lib.RequestHandler,
+	logger lib.Logger,
+	env lib.Env,
+	db lib.Database,
+) DatabaseTrx {
+	return DatabaseTrx{
+		handler: handler,
+		logger:  logger,
+		db:      db,
+	}
+}
+
+// Setup sets up cors middleware
+func (m DatabaseTrx) Setup() {
+	m.logger.Zap.Info("Setting up cors middleware")
+
+	m.handler.Gin.Use(func(c *gin.Context) {
+		txHandle := m.db.DB.Begin()
+		m.logger.Zap.Info("Build transaction")
+
+		defer func() {
+			if r := recover(); r != nil {
+				txHandle.Rollback()
+			}
+		}()
+
+		c.Set(constants.DBTransaction, txHandle)
+		c.Next()
+
+		// rollback transaction when error
+		if c.Writer.Status() == http.StatusInternalServerError {
+			m.logger.Zap.Info("rolling back transaction due to status code: 500")
+			txHandle.Rollback()
+		}
+
+		// commit transaction on ok status
+		if c.Writer.Status() == http.StatusOK {
+			m.logger.Zap.Info("committing transactions")
+			if err := txHandle.Commit().Error; err != nil {
+				m.logger.Zap.Error("trx commit error: ", err)
+			}
+		}
+	})
+}

--- a/api/middlewares/middlewares.go
+++ b/api/middlewares/middlewares.go
@@ -6,6 +6,7 @@ import "go.uber.org/fx"
 var Module = fx.Options(
 	fx.Provide(NewCorsMiddleware),
 	fx.Provide(NewJWTAuthMiddleware),
+	fx.Provide(NewDatabaseTrx),
 	fx.Provide(NewMiddlewares),
 )
 
@@ -19,9 +20,13 @@ type Middlewares []IMiddleware
 
 // NewMiddlewares creates new middlewares
 // Register the middleware that should be applied directly (globally)
-func NewMiddlewares(corsMiddleware CorsMiddleware) Middlewares {
+func NewMiddlewares(
+	corsMiddleware CorsMiddleware,
+	dbTrxMiddleware DatabaseTrx,
+) Middlewares {
 	return Middlewares{
 		corsMiddleware,
+		dbTrxMiddleware,
 	}
 }
 

--- a/api/repository/user_repository.go
+++ b/api/repository/user_repository.go
@@ -3,18 +3,31 @@ package repository
 import (
 	"github.com/dipeshdulal/clean-gin/lib"
 	"github.com/dipeshdulal/clean-gin/models"
+	"github.com/jinzhu/gorm"
 )
 
 // UserRepository database structure
 type UserRepository struct {
-	db lib.Database
+	db     lib.Database
+	logger lib.Logger
 }
 
 // NewUserRepository creates a new user repository
-func NewUserRepository(db lib.Database) UserRepository {
+func NewUserRepository(db lib.Database, logger lib.Logger) UserRepository {
 	return UserRepository{
-		db: db,
+		db:     db,
+		logger: logger,
 	}
+}
+
+// WithTrx enables repository with transaction
+func (r UserRepository) WithTrx(trxHandle *gorm.DB) UserRepository {
+	if trxHandle == nil {
+		r.logger.Zap.Error("Transaction Database not found in gin context. ")
+		return r
+	}
+	r.db.DB = trxHandle
+	return r
 }
 
 // GetAll gets all users

--- a/api/routes/user.go
+++ b/api/routes/user.go
@@ -2,8 +2,8 @@ package routes
 
 import (
 	"github.com/dipeshdulal/clean-gin/api/controllers"
-	"github.com/dipeshdulal/clean-gin/lib"
 	"github.com/dipeshdulal/clean-gin/api/middlewares"
+	"github.com/dipeshdulal/clean-gin/lib"
 )
 
 // UserRoutes struct
@@ -22,6 +22,7 @@ func (s UserRoutes) Setup() {
 		api.GET("/user", s.userController.GetUser)
 		api.GET("/user/:id", s.userController.GetOneUser)
 		api.POST("/user", s.userController.SaveUser)
+		api.POST("/user-no-trx", s.userController.SaveUserWOTrx)
 		api.POST("/user/:id", s.userController.UpdateUser)
 		api.DELETE("/user/:id", s.userController.DeleteUser)
 	}

--- a/api/services/user_service.go
+++ b/api/services/user_service.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dipeshdulal/clean-gin/lib"
 	"github.com/dipeshdulal/clean-gin/models"
 	"github.com/jinzhu/copier"
+	"github.com/jinzhu/gorm"
 )
 
 // UserService service layer
@@ -19,6 +20,12 @@ func NewUserService(logger lib.Logger, repository repository.UserRepository) Use
 		logger:     logger,
 		repository: repository,
 	}
+}
+
+// WithTrx delegates transaction to repository database
+func (s UserService) WithTrx(trxHandle *gorm.DB) UserService {
+	s.repository = s.repository.WithTrx(trxHandle)
+	return s
 }
 
 // GetOneUser gets one user

--- a/constants/context.go
+++ b/constants/context.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	// DBTransaction is database transaction handle set at router context
+	DBTransaction = "db_trx"
+)


### PR DESCRIPTION
This pull request adds [database transactions](https://gorm.io/docs/transactions.html#content-inner) middle ware for gin. After the use of middle ware the transactions are automatically created, committed and rolled back by looking at the returned response.

#### Transaction automatic create, commit, rollback details:
| Event | When |
| -- | -- |
| `create` | On every api request |
| `commit` | If request has responded with 200 response |
| `rollback` | If request has responded with 500 response | 
 

#### Usage:
To use this feature transaction user will have to delegate transaction handle to repository layer using `WithTrx` method. In the service layer we could;
```go
// WithTrx delegates transaction to repository database
func (s UserService) WithTrx(trxHandle *gorm.DB) UserService {
	s.repository = s.repository.WithTrx(trxHandle)
	return s
}
```
And in the repository layer we need to replace current database instance with the provided instance by doing;
```go
// WithTrx enables repository with transaction
func (r UserRepository) WithTrx(trxHandle *gorm.DB) UserRepository {
	if trxHandle == nil {
		r.logger.Zap.Error("Transaction Database not found. ")
		return r
	}
	r.db.DB = trxHandle
	return r
}
```

In the controller layer where transaction is required you can simply do;
```go
u.service.WithTrx(trxHandle).CreateUser(user)
```
And for the tasks that don't require transactions removing `WithTrx(trxHandle)` will do the trick. 

For reference I have added  saving user without transactions. 8831d77 