### PR TITLE
Fixed transactions not being closed in database transaction middleware

### DIFF
--- a/api/middlewares/db_trx.go
+++ b/api/middlewares/db_trx.go
@@ -55,18 +55,15 @@ func (m DatabaseTrx) Setup() {
 		c.Set(constants.DBTransaction, txHandle)
 		c.Next()
 
-		// rollback transaction on server errors
-		if c.Writer.Status() == http.StatusInternalServerError {
-			m.logger.Info("rolling back transaction due to status code: 500")
-			txHandle.Rollback()
-		}
-
 		// commit transaction on success status
-		if statusInList(c.Writer.Status(), []int{http.StatusOK, http.StatusCreated}) {
+		if statusInList(c.Writer.Status(), []int{http.StatusOK, http.StatusCreated, http.StatusNoContent}) {
 			m.logger.Info("committing transactions")
 			if err := txHandle.Commit().Error; err != nil {
 				m.logger.Error("trx commit error: ", err)
 			}
+		} else {
+			m.logger.Info("rolling back transaction due to status code: 500")
+			txHandle.Rollback()
 		}
 	})
 }


### PR DESCRIPTION
Responding with any http codes outside of 200, 201 and 500 would keep not close database transactions.